### PR TITLE
Dealing with changes in rhdf5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cmapR
 Type: Package
 Title: CMap tools in R
-Version: 1.0
+Version: 1.0.1
 Date: 2017-03-29
 Author: CMap Group at The Broad Institute
 Maintainer: <clue@broadinstitute.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: cmapR
 Type: Package
 Title: CMap tools in R
 Version: 1.0.1
-Date: 2017-03-29
+Date: 2018-01-30
 Author: CMap Group at The Broad Institute
 Maintainer: <clue@broadinstitute.org>
 Description: CMAP tools in R

--- a/R/io.R
+++ b/R/io.R
@@ -497,7 +497,6 @@ setMethod("initialize",
                   .Object@cdesc <- data.frame(id=.Object@cid, stringsAsFactors = F)
                 }
                 # close any open handles and return the object
-                # close any open handles
                 if(utils::packageVersion('rhdf5') < "2.23.0") {
                     H5close()
                 } else {

--- a/R/io.R
+++ b/R/io.R
@@ -497,7 +497,12 @@ setMethod("initialize",
                   .Object@cdesc <- data.frame(id=.Object@cid, stringsAsFactors = F)
                 }
                 # close any open handles and return the object
-                H5close()
+                # close any open handles
+                if(utils::packageVersion('rhdf5') < "2.23.0") {
+                    H5close()
+                } else {
+                    h5closeAll()
+                }
                 message("done")
               }
             }
@@ -760,12 +765,16 @@ write.gctx <- function(ds, ofile, appenddim=T, compression_level=0, matrix_only=
   }
 
   # close any open handles
-  H5close()
+  if(utils::packageVersion('rhdf5') < "2.23.0") {
+    H5close()
+  } else {
+    h5closeAll()
+  }
 
   # add the version annotation and close
   fid <- H5Fopen(ofile)
   h5writeAttribute("GCTX1.0", fid, "version")
-  H5close()
+  H5Fclose(fid)
 
 }
 


### PR DESCRIPTION
The behaviour of `rhdf5::H5close()` has changed as a result of updating the underlying HDF5 library.  Invoking `H5close()` now not only closes any open object handles, but also shuts down the C-library so nothing works after, rending it fairly useless.  The functionality to close any open objects can now be achieved with `h5closeAll()`.

The changes in this pull request should make the affected **cmapR** functions compatible with both the 'old' version of **rhdf5** e.g. versions < 2.23.0, and also the changed behaviour in **rhdf5** >= 2.23.0.

